### PR TITLE
Fix of incompatibility with Tornado>=4.5

### DIFF
--- a/shelter/core/app.py
+++ b/shelter/core/app.py
@@ -24,6 +24,15 @@ def get_tornado_apps(context, debug=False):
         if not urls:
             urls = [tornado.web.URLSpec('/', NullHandler)]
         for url in urls:
+            # There is change in implementation of tornado.web.URLSpec.
+            # From Tornado 4.5 we have to use target_kwargs property
+            # of base class of tornado.web.URLSpec: tornado.routing.Rule.
+            if hasattr(url, 'target_kwargs'):
+                # We have newer version of Tornado
+                url.target_kwargs['context'] = context
+                url.target_kwargs['interface'] = interface
+                url.kwargs = {}
+            # Always do it old way
             url.kwargs['context'] = context
             url.kwargs['interface'] = interface
         apps.append(


### PR DESCRIPTION
There is change in implementation of tornado.web.URLSpec. 