### PR TITLE
Allow custom class instead of tornado.web.Application

### DIFF
--- a/shelter/core/app.py
+++ b/shelter/core/app.py
@@ -11,6 +11,16 @@ from shelter.utils.imports import import_object
 __all__ = ['get_tornado_apps']
 
 
+def get_app_class(context):
+    """
+    Import and eturn tornado app class specified in settings or return vanilla
+    one (:class:`tornado.web.Application`).
+    """
+    if context.config.tornado_app_class is not None:
+        return import_object(context.config.tornado_app_class)
+    return tornado.web.Application
+
+
 def get_tornado_apps(context, debug=False):
     """
     Create Tornado's application for all interfaces which are defined
@@ -26,13 +36,15 @@ def get_tornado_apps(context, debug=False):
     else:
         settings = {}
 
+    app_class = get_app_class(context)
+
     apps = []
     for interface in context.config.interfaces:
         urls = interface.urls
         if not urls:
             urls = [tornado.web.URLSpec('/', NullHandler)]
         apps.append(
-            tornado.web.Application(
+            app_class(
                 urls, debug=debug, context=context,
                 interface=interface, **settings
             )

--- a/shelter/core/config.py
+++ b/shelter/core/config.py
@@ -215,3 +215,12 @@ class Config(object):
         ``tornado.web.Application`` constructor.
         """
         return getattr(self.settings, 'APP_SETTINGS_HANDLER', None)
+
+    @property
+    def tornado_app_class(self):
+        """
+        Either subclass of :class:`tornado.web.Application` which should be
+        used for initializing server or :const:`None`, then vanilla
+        application class will be used.
+        """
+        return getattr(self.settings, 'TORNADO_APP_CLASS', None)


### PR DESCRIPTION
When integrating opentracing to our app based on shelter I had bit hard time to correctly patch tornado app class. It greatly helped me to be able provide custom one to shelter.

Edit: I've found no guide on how to contribute, so I hope for your pointers.